### PR TITLE
Initialize project scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Binaries
+/bin/
+*/bin/
+# Vendor
+/vendor/
+# Build
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-This is a side project.
+# Now Playing Feed
+
+This project aims to provide a real-time feed of what your friends are currently listening to on Spotify or Apple Music.
+
+## Overview
+
+A Go-based REST and WebSocket API delivers live updates using goroutines for concurrent stream handling. Redis provides Pub/Sub channels for instant event delivery and stores recent listening history in Redis Streams. A lightweight message broker such as NATS JetStream buffers events when users are offline and replays them when they reconnect.
+

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"github.com/example/play_now/internal/api"
+	"log"
+)
+
+func main() {
+	s := api.NewServer()
+	log.Fatal(s.Run())
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/example/play_now
+
+go 1.22
+
+require (
+    github.com/gorilla/mux v1.8.0
+    github.com/gorilla/websocket v1.5.0
+    github.com/redis/go-redis/v9 v9.0.0
+    github.com/nats-io/nats.go v1.24.0
+)
+

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"github.com/gorilla/mux"
+	"net/http"
+)
+
+// Server holds the HTTP server configuration.
+type Server struct {
+	httpServer *http.Server
+}
+
+// NewServer creates a new API server with default routes.
+func NewServer() *Server {
+	r := mux.NewRouter()
+	// placeholder routes
+	r.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv := &http.Server{Addr: ":8080", Handler: r}
+	return &Server{httpServer: srv}
+}
+
+// Run starts the HTTP server.
+func (s *Server) Run() error {
+	return s.httpServer.ListenAndServe()
+}

--- a/internal/queue/nats.go
+++ b/internal/queue/nats.go
@@ -1,0 +1,24 @@
+package queue
+
+import (
+	"context"
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Client handles the connection to NATS JetStream.
+type Client struct {
+	js jetstream.JetStream
+}
+
+// New creates a new NATS JetStream client.
+func New(ctx context.Context, url string) (*Client, error) {
+	nc, err := jetstream.Connect(url)
+	if err != nil {
+		return nil, err
+	}
+	js, err := jetstream.New(nc)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{js: js}, nil
+}

--- a/internal/redis/redis.go
+++ b/internal/redis/redis.go
@@ -1,0 +1,22 @@
+package redis
+
+import (
+	"context"
+	"github.com/redis/go-redis/v9"
+)
+
+// Client wraps the redis client used throughout the service.
+type Client struct {
+	*redis.Client
+}
+
+// New creates a new redis client instance.
+func New(addr string) *Client {
+	r := redis.NewClient(&redis.Options{Addr: addr})
+	return &Client{Client: r}
+}
+
+// Ping checks connectivity with redis.
+func (c *Client) Ping(ctx context.Context) error {
+	return c.Client.Ping(ctx).Err()
+}

--- a/internal/ws/manager.go
+++ b/internal/ws/manager.go
@@ -1,0 +1,31 @@
+package ws
+
+import (
+	"github.com/gorilla/websocket"
+	"sync"
+)
+
+// Manager handles active WebSocket connections.
+type Manager struct {
+	connections map[*websocket.Conn]struct{}
+	mu          sync.Mutex
+}
+
+// NewManager returns a new connection manager.
+func NewManager() *Manager {
+	return &Manager{connections: make(map[*websocket.Conn]struct{})}
+}
+
+// Add registers a new connection.
+func (m *Manager) Add(conn *websocket.Conn) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.connections[conn] = struct{}{}
+}
+
+// Remove unregisters a connection.
+func (m *Manager) Remove(conn *websocket.Conn) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.connections, conn)
+}


### PR DESCRIPTION
## Summary
- setup Go module and dependencies
- add server entrypoint and HTTP server skeleton
- create websocket manager, redis and queue clients
- document project purpose in README
- add .gitignore

## Testing
- `go vet ./...` *(fails: module fetch forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6845ee1dbc588331aa8b407b55576851